### PR TITLE
Remove listeners when closing websocket

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-unifi-os",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Nodes to access UniFi data using endpoints and websockets",
   "main": "build/nodes/unifi.js",
   "scripts": {

--- a/src/nodes/WebSocket.ts
+++ b/src/nodes/WebSocket.ts
@@ -37,11 +37,9 @@ module.exports = (RED: NodeAPI) => {
         action: string,
         callback: () => void
     ): Promise<void> => {
+        self.ws?.removeAllListeners()
         self.ws?.close(1000, `Node ${action}`)
         self.ws?.terminate()
-        if (self.ws !== undefined) {
-            self.ws.removeAllListeners();
-        }
         self.ws = undefined
         callback()
     }

--- a/src/nodes/WebSocket.ts
+++ b/src/nodes/WebSocket.ts
@@ -39,6 +39,9 @@ module.exports = (RED: NodeAPI) => {
     ): Promise<void> => {
         self.ws?.close(1000, `Node ${action}`)
         self.ws?.terminate()
+        if (self.ws !== undefined) {
+            self.ws.removeAllListeners();
+        }
         self.ws = undefined
         callback()
     }


### PR DESCRIPTION
Thank's @marcus-j-davies for the suggestion. I've noticed "extra messages" at times with web sockets. Suggestion is to be sure listeners are destroyed properly before opening a new connection.

Please review, @Shaquu