### PR TITLE
fix(Request): forward Buffer & string payloads again

### DIFF
--- a/src/nodes/Request.ts
+++ b/src/nodes/Request.ts
@@ -104,10 +104,8 @@ module.exports = (RED: NodeAPI) => {
                         shape: 'dot',
                         text: 'Sent',
                     })
-                    log.debug('Result:')
+                    log.debug(`Result (${typeof data}):`)
                     log.trace(util.inspect(data))
-
-                    console.log(typeof data)
 
                     const _send = (Result: UnifiResponse) => {
                         self.send({
@@ -116,7 +114,9 @@ module.exports = (RED: NodeAPI) => {
                         })
                     }
 
-                    if (!Buffer.isBuffer(data) && typeof data !== 'string') {
+                    if (Buffer.isBuffer(data) || typeof data === 'string') {
+                        self.send({ payload: data, inputMsg: msg })
+                    } else {
                         _send(data)
                     }
                 })


### PR DESCRIPTION
## What happened

PR #74 added a type‑safety guard to src/nodes/Request.ts:
```ts
const _send = (Result: UnifiResponse) => {
    self.send({
        payload: Result,
        inputMsg: msg,
    })
}
if (!Buffer.isBuffer(data) && typeof data !== 'string') {
    _send(data)
}
```

The guard works for JSON endpoints, but it silently drops every UniFi endpoint that returns raw bytes or plain text — most notably the Protect /snapshot thumbnails that are requested with `responseType: 'arraybuffer'`.
Since those thumbnails are delivered as Node Buffers, downstream flows never see them.

## What this PR does
* Restores the pre‑1.1 behaviour for binary and text payloads.
* Keeps the stricter `UnifiResponse` typing for all JSON endpoints.
* Collateral cleanup: Removes the console.log (moving the type printed into another debug log)

fixes #90 